### PR TITLE
Allow to specify alternative (not always 'localhost') Selenium server url

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,14 @@
     <php>
         <!--server name="WEB_FIXTURES_HOST" value="http://test.mink.dev" /-->
         <!--server name="WEB_FIXTURES_BROWSER" value="firefox" /-->
+
+		<!-- where driver will connect to -->
+		<server name="DRIVER_HOST" value="127.0.0.1" />
+		<server name="DRIVER_PORT" value="4444" />
+
+		<!-- where DocumentRoot of 'Test Machine' is mounted to on 'Driver Machine' (only if these are 2 different machines) -->
+		<!--server name="DRIVER_MACHINE_BASE_PATH" value="" /-->
+		<!--server name="TEST_MACHINE_BASE_PATH" value="" /-->
     </php>
 
     <filter>

--- a/tests/Behat/Mink/Driver/SeleniumDriverTest.php
+++ b/tests/Behat/Mink/Driver/SeleniumDriverTest.php
@@ -15,7 +15,7 @@ class SeleniumDriverTest extends JavascriptDriverTest
         $browser = '*'.$_SERVER['WEB_FIXTURES_BROWSER'];
         $baseUrl = $_SERVER['WEB_FIXTURES_HOST'];
 
-        return new SeleniumDriver($browser, $baseUrl, new SeleniumClient('127.0.0.1', 4444));
+        return new SeleniumDriver($browser, $baseUrl, new SeleniumClient($_SERVER['DRIVER_HOST'], $_SERVER['DRIVER_PORT']));
     }
 
     public function testMouseEvents() {} // Right click and blur are not supported


### PR DESCRIPTION
Allows to use any Selenium server for testing `SeleniumDriver` itself, not only `127.0.0.1`, as was before.

Also setting for server path mapping (see https://github.com/Behat/Mink/issues/342 pull request).

Similar PR was made to Selenium2Driver: https://github.com/Behat/MinkSelenium2Driver/pull/56
