### PR TITLE
Use native `getAttribute` method of the underlying library

### DIFF
--- a/src/Behat/Mink/Driver/SeleniumDriver.php
+++ b/src/Behat/Mink/Driver/SeleniumDriver.php
@@ -291,7 +291,7 @@ class SeleniumDriver extends CoreDriver
      */
     public function getAttribute($xpath, $name)
     {
-        $result = $this->getCrawler()->filterXPath($xpath)->attr($name);
+        $result = $this->browser->getAttribute(SeleniumLocator::xpath('(' . $xpath . ')@' . $name));
         if ('' === $result) {
             $result = null;
         }


### PR DESCRIPTION
Use native `getAttribute` method of the underlying library instead of crawling whole document. This works faster, than crawling and gives same results.

Depends on following PR's:
- https://github.com/alexandresalome/PHP-Selenium/pull/6
- https://github.com/alexandresalome/PHP-Selenium/pull/5
