### PR TITLE
Use dev version of Mink during Travis testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php":                           ">=5.3.1",
         "behat/mink":                    "~1.5.0@dev",
-        "alexandresalome/php-selenium":  "~1.0.1",
+        "alexandresalome/php-selenium":  "~1.0.1@dev",
         "symfony/dom-crawler":           "~2.0"
     },
 


### PR DESCRIPTION
Separating tests from a driver repo into a separate repo is great idea, when we're talking about code duplication. But isn't not that great idea, when to implement a feature a 2 different PR's are created for the driver repo and the Mink repo, where tests are added.

In such case Travis isn't aware of that and isn't including newly added tests in the build being tested.

I'm proposing to ease a situation a bit and reply on `~1.5@dev` version of `Mink` in Travis builds. This would allow build to include new tests as long as associated Mink's PR will be merged into `develop` branch before driver PR is tested.

I know, that due both processes (merging/testing) are asynchronous, that we might want to rerun tests on Travis side by hand, but it's still better then new tests not being executed at all.

Similar PR's:
- https://github.com/Behat/MinkSelenium2Driver/pull/90
