### PR TITLE
Use pure JavaScript code for node attribute retrieval

### DIFF
--- a/src/Behat/Mink/Driver/SeleniumDriver.php
+++ b/src/Behat/Mink/Driver/SeleniumDriver.php
@@ -291,11 +291,16 @@ class SeleniumDriver extends CoreDriver
      */
     public function getAttribute($xpath, $name)
     {
-        $result = $this->getCrawler()->filterXPath($xpath)->attr($name);
-        if ('' === $result) {
-            $result = null;
-        }
-        return $result;
+        $xpathEscaped = json_encode($xpath);
+        $nameEscaped = json_encode((string)$name);
+
+        $script = <<<JS
+var node = this.browserbot.locateElementByXPath($xpathEscaped, window.document);
+
+JSON.stringify(node.getAttribute($nameEscaped))
+JS;
+
+        return json_decode($this->browser->getEval($script), true);
     }
 
     /**


### PR DESCRIPTION
Use pure JavaScript code for node attribute retrieval to be consistent with https://github.com/Behat/MinkSelenium2Driver/pull/89.

This is an improvement over #16.

Related to https://github.com/Behat/Mink/issues/389.
