### PR TITLE
Cookie was only deleted from current path

### DIFF
--- a/src/Behat/Mink/Driver/SeleniumDriver.php
+++ b/src/Behat/Mink/Driver/SeleniumDriver.php
@@ -206,7 +206,7 @@ class SeleniumDriver extends CoreDriver
     public function setCookie($name, $value = null)
     {
         if (null === $value) {
-            $this->browser->deleteCookie($name, '');
+            $this->browser->deleteCookie($name, 'recurse=true');
         } else {
             $this->browser->createCookie($name.'='.$value, '');
         }


### PR DESCRIPTION
When deleting a cookie using `->setCookie('cookieName')` code, then only cookie from current path was deleted. This way if cookie was set on `/index.html` page, then it could not be deleted, while being on `/sub-folder/sub-page.html`.

Tests in https://github.com/Behat/Mink/pull/418
