### PR TITLE
Switch to the container-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 php: [5.3, 5.4, 5.5, 5.6, hhvm]
 
 matrix:
@@ -10,7 +16,7 @@ matrix:
 
 env:
   global:
-    - WEB_FIXTURES_HOST=http://localhost
+    - WEB_FIXTURES_HOST=http://localhost:8000
     - WEB_FIXTURES_BROWSER=firefox
 
 before_script:
@@ -18,19 +24,14 @@ before_script:
   - export DISPLAY=:99.0
   - sleep 4
 
-  - curl -L http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar > selenium.jar
-  - sudo ln -s /usr/lib/firefox/firefox /usr/lib/firefox/firefox-bin
-  - PATH=$PATH:/usr/lib/firefox java -jar selenium.jar > /dev/null 2>&1 &
-  - sleep 4
+  - curl -L http://selenium-release.storage.googleapis.com/2.46/selenium-server-standalone-2.46.0.jar > selenium.jar
+  - java -jar selenium.jar > /dev/null 2>&1 &
 
-  - sh -c 'if [ "$CRAWLER_VERSION" != "" ]; then composer require --no-update symfony/dom-crawler=$CRAWLER_VERSION; fi;'
-  - composer install --dev --prefer-source
+  - if [ "$CRAWLER_VERSION" != "" ]; then composer require --no-update symfony/dom-crawler=$CRAWLER_VERSION; fi
+  - composer install
 
-  - sudo apt-get update -qq
-  - sudo apt-get install -y --force-yes apache2 libapache2-mod-php5
-  - sudo sed -i -e "s,/var/www,$(pwd)/vendor/behat/mink/driver-testsuite/web-fixtures,g" /etc/apache2/sites-available/default
-  - sudo /etc/init.d/apache2 restart
-
+   # Start a webserver for web fixtures. Force using PHP 5.6 to be able to run it on PHP 5.3 and HHVM jobs too
+  - ~/.phpenv/versions/5.6/bin/php -S localhost:8000 -t vendor/behat/mink/driver-testsuite/web-fixtures > /dev/null 2>&1 &
 
 script: phpunit -v --coverage-clover=coverage.clover
 


### PR DESCRIPTION
This uses the PHP builtin webserver to expose web fixtures rather than installing Apache. This relies on the fact that PHP 5.6 is installed on Travis even on jobs running with a different version, and so can be used for fixtures on all jobs (and we don't care about the PHP version used to run fixtures as we were not using the Travis one before anyway).